### PR TITLE
Return an :ok on the cookie security setup

### DIFF
--- a/modules/2-owasp.livemd
+++ b/modules/2-owasp.livemd
@@ -11,7 +11,6 @@ Mix.install([
 
 md5_hash = :crypto.hash(:md5, "users_password")
 bcrypt_salted_hash = Bcrypt.hash_pwd_salt("users_password")
-
 :ok
 ```
 

--- a/modules/6-cookies.livemd
+++ b/modules/6-cookies.livemd
@@ -6,6 +6,7 @@ Mix.install([:phoenix, :plug])
 alias Phoenix.ConnTest
 alias Plug
 conn = ConnTest.build_conn()
+:ok
 ```
 
 ## Introduction


### PR DESCRIPTION
Bug fix for submission by [michaeldbianchi](https://github.com/michaeldbianchi): 

Currently, the cookie security module's setup ends on building a plug connection. It's just a little strange that the return value from the cell is the actual Plug.Conn struct. Assuming the cell completes, it will now just return an :ok like the other modules
