### PR TITLE
use `:benchwarmer` from mroth/benchwarmer@12b5a96

### DIFF
--- a/modules/5-elixir.livemd
+++ b/modules/5-elixir.livemd
@@ -5,7 +5,7 @@
 ```elixir
 Mix.install([
   {:grading_client, path: "#{__DIR__}/grading_client"},
-  :benchwarmer,
+  {:benchwarmer, github: "mroth/benchwarmer", ref: "12b5a96b38cef09f2bd49e5c2dd5024100c1e8af"},
   :kino,
   :plug
 ])


### PR DESCRIPTION
Saw the following issue when running with Elixir 1.18.3 and OTP 27. `:benchwarmer` is outdated and `v0.0.3` was never released on hex.pm.

```
    error: undefined variable "deps"
    │
  9 │       deps:         deps,
    │                     ^^^^
    │
    └─ /Users/cocoa/Library/Caches/mix/installs/elixir-1.17.2-erts-15.0/914f3a4f6f6fc1e79b2bec3e4f0efe0b/deps/benchwarmer/mix.exs:9:21: Benchwarmer.Mixfile.project/0

    error: undefined variable "description"
    │
 12 │       description:  description,
    │                     ^^^^^^^^^^^
    │
    └─ /Users/cocoa/Library/Caches/mix/installs/elixir-1.17.2-erts-15.0/914f3a4f6f6fc1e79b2bec3e4f0efe0b/deps/benchwarmer/mix.exs:12:21: Benchwarmer.Mixfile.project/0

    error: undefined variable "package"
    │
 13 │       package:      package
    │                     ^^^^^^^
    │
    └─ /Users/cocoa/Library/Caches/mix/installs/elixir-1.17.2-erts-15.0/914f3a4f6f6fc1e79b2bec3e4f0efe0b/deps/benchwarmer/mix.exs:13:21: Benchwarmer.Mixfile.project/0

    warning: function deps/0 is unused
    │
 53 │   defp deps do
    │        ~
    │
    └─ /Users/cocoa/Library/Caches/mix/installs/elixir-1.17.2-erts-15.0/914f3a4f6f6fc1e79b2bec3e4f0efe0b/deps/benchwarmer/mix.exs:53:8: Benchwarmer.Mixfile (module)

    warning: function description/0 is unused
    │
 17 │   defp description do
    │        ~
    │
    └─ /Users/cocoa/Library/Caches/mix/installs/elixir-1.17.2-erts-15.0/914f3a4f6f6fc1e79b2bec3e4f0efe0b/deps/benchwarmer/mix.exs:17:8: Benchwarmer.Mixfile (module)

    warning: function package/0 is unused
    │
 26 │   defp package do
    │        ~
    │
    └─ /Users/cocoa/Library/Caches/mix/installs/elixir-1.17.2-erts-15.0/914f3a4f6f6fc1e79b2bec3e4f0efe0b/deps/benchwarmer/mix.exs:26:8: Benchwarmer.Mixfile (module)

Error while loading project :benchwarmer at /Users/cocoa/Library/Caches/mix/installs/elixir-1.17.2-erts-15.0/914f3a4f6f6fc1e79b2bec3e4f0efe0b/deps/benchwarmer
```