### PR TITLE
Put `Mix.install` in the setup cell

### DIFF
--- a/modules/5-elixir.livemd
+++ b/modules/5-elixir.livemd
@@ -1,7 +1,5 @@
 # ESCT: Part 5 - Elixir Security
 
-## Section
-
 ```elixir
 Mix.install([
   {:grading_client, path: "#{__DIR__}/grading_client"},


### PR DESCRIPTION
Removed the extra `## Section` at the beginning so `Mix.install` is in the setup cell.